### PR TITLE
added gold-plaques for pokemon that are legendary, mega, mythical

### DIFF
--- a/src/components/PokemonDetailed/index.js
+++ b/src/components/PokemonDetailed/index.js
@@ -65,6 +65,9 @@ export default function PokemonDetailed({
   height,
   weight,
   starter,
+  legendary,
+  mega,
+  mythical,
   gen,
   image
 }) {
@@ -94,6 +97,24 @@ export default function PokemonDetailed({
           <span className="starter">
             <StarsOutlinedIcon />
             STARTER
+          </span>
+        ) : null}
+        {legendary ? (
+          <span className="starter">
+            <StarsOutlinedIcon />
+            LEGENDARY
+          </span>
+        ) : null}
+        {mega ? (
+          <span className="starter">
+            <StarsOutlinedIcon />
+            MEGA
+          </span>
+        ) : null}
+        {mythical ? (
+          <span className="starter">
+            <StarsOutlinedIcon />
+            MYTHICAL
           </span>
         ) : null}
       </CardMedia>

--- a/src/views/PokemonDetails/index.js
+++ b/src/views/PokemonDetails/index.js
@@ -66,6 +66,9 @@ export default function PokemonDetails() {
             height={pokemon.height}
             weight={pokemon.weight}
             starter={pokemon.starter}
+            legendary={pokemon.legendary}
+            mega={pokemon.mega}
+            mythical={pokemon.mythical}
             gen={pokemon.gen}
             image={pokemon.sprite}
           />


### PR DESCRIPTION
totally forgot about that. it's the same as with the starters-plaque that was already there. depending if they are true, a gold plaque is schon on the bottom left of the picture. wasn't really necessary, but a nice touch and i already did it for the starters and forgot to do the others. and so we use most of the data from the api